### PR TITLE
test(ci): add ci to check image version and chart version

### DIFF
--- a/.github/workflows/lint-image-chart-versions.yml
+++ b/.github/workflows/lint-image-chart-versions.yml
@@ -20,13 +20,13 @@ jobs:
           devlake_version_text=$(yq .lake.image.tag ${GITHUB_WORKSPACE}/charts/devlake/values.yaml)
           grafana_version_text=$(yq .grafana.image.tag ${GITHUB_WORKSPACE}/charts/devlake/values.yaml)
           configui_version_text=$(yq .ui.image.tag ${GITHUB_WORKSPACE}/charts/devlake/values.yaml)
-          if [[ $chart_version_text != $devlake_version_text ]] ; then
+          if [[ v$chart_version_text != $devlake_version_text ]] ; then
             echo chart version $chart_version_text is not equal to  devlake version $devlake_version_text
             exit 1
-          elif [[ $chart_version_text != $grafana_version_text ]] ; then
+          elif [[ v$chart_version_text != $grafana_version_text ]] ; then
             echo chart version $chart_version_text is not equal to  grafana version $grafana_version_text
             exit 1
-          elif [[ $chart_version_text != $devlake_version_text ]] ; then
+          elif [[ v$chart_version_text != $devlake_version_text ]] ; then
             echo chart version $chart_version_text is not equal to  configui version $configui_version_text
             exit 1
           else 

--- a/.github/workflows/lint-image-chart-versions.yml
+++ b/.github/workflows/lint-image-chart-versions.yml
@@ -1,0 +1,34 @@
+name: validate image and chart version
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - charts/**
+jobs:
+  check:
+    name: validate image and chart version
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: install yq
+        run: echo yq should already in github ubuntu-latest
+      - name: chart version align with image version
+        run: |
+          set -e
+          chart_version_text=$(yq .version ${GITHUB_WORKSPACE}/charts/devlake/Chart.yaml)
+          devlake_version_text=$(yq .lake.image.tag ${GITHUB_WORKSPACE}/charts/devlake/values.yaml)
+          grafana_version_text=$(yq .grafana.image.tag ${GITHUB_WORKSPACE}/charts/devlake/values.yaml)
+          configui_version_text=$(yq .ui.image.tag ${GITHUB_WORKSPACE}/charts/devlake/values.yaml)
+          if [[ $chart_version_text != $devlake_version_text ]] ; then
+            echo chart version $chart_version_text is not equal to  devlake version $devlake_version_text
+            exit 1
+          elif [[ $chart_version_text != $grafana_version_text ]] ; then
+            echo chart version $chart_version_text is not equal to  grafana version $grafana_version_text
+            exit 1
+          elif [[ $chart_version_text != $devlake_version_text ]] ; then
+            echo chart version $chart_version_text is not equal to  configui version $configui_version_text
+            exit 1
+          else 
+            echo all images version are equal to chart version
+          fi


### PR DESCRIPTION
 A few weeks ago, we build a chart release with wrong images. So  we add this `ci` to check if image versions are equal to chart version.
We separate this `ci` from lint-chart-versions.yml because when we use version with `rc` tag we cannot pass lint-chart-versions.yml

<img width="609" alt="image" src="https://user-images.githubusercontent.com/39366025/215666181-b2dc2c9f-0ffc-4e12-b962-ad8be613eaba.png">

<img width="530" alt="image" src="https://user-images.githubusercontent.com/39366025/215666303-75f639c1-08a4-4ed1-85e5-d0a6c6df0e3a.png">
