### PR TITLE
feat: add some args to mysql container

### DIFF
--- a/charts/devlake/templates/statefulsets.yaml
+++ b/charts/devlake/templates/statefulsets.yaml
@@ -40,6 +40,11 @@ spec:
         - name: mysql
           image: "{{ .Values.mysql.image.repository }}:{{ .Values.mysql.image.tag }}"
           imagePullPolicy: {{ .Values.mysql.image.pullPolicy }}
+          args:
+            - "mysqld"
+            - "--character-set-server=utf8mb4"
+            - "--collation-server=utf8mb4_bin"
+            - "--skip-log-bin"
           ports:
             - name: mysql
               containerPort: 3306


### PR DESCRIPTION
$ kg pod
```sh
NAME                               READY   STATUS    RESTARTS   AGE
devlake-grafana-66fb6f4b5c-vll9t   1/1     Running   0          91s
devlake-lake-0                     1/1     Running   0          9s
devlake-mysql-0                    1/1     Running   0          91s
devlake-ui-68c89ccbff-ghft9        1/1     Running   0          91s
```

I've test this change locally.

## tips

- MySQL Dockerfile

![image](https://user-images.githubusercontent.com/18692628/228188328-a899df34-758c-4d6d-9c47-81abc07851d2.png)

- entrypoint -> command
- cmd -> args
