### PR TITLE
feat: enable selection of default Nginx ingress vs generic one.

### DIFF
--- a/charts/devlake/templates/ingresses.yaml
+++ b/charts/devlake/templates/ingresses.yaml
@@ -36,7 +36,9 @@ metadata:
   labels:
     {{- include "devlake.labels" . | nindent 4 }}
   annotations:
+  {{- if .Values.ingress.useDefaultNginx }}
     nginx.ingress.kubernetes.io/rewrite-target: /$2
+  {{- end}}
   {{- with .Values.ingress.annotations }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
@@ -55,7 +57,11 @@ spec:
       http:
         paths:
           {{- if not .Values.grafana.useExternal }}
+          {{- if .Values.ingress.useDefaultNginx }}
           - path: /{{ include "devlake.grafanaEndpointPrefix" . }}(/|$)(.*)
+          {{- else }}
+          - path: /{{ include "devlake.grafanaEndpointPrefix" . }}
+          {{- end }}
             {{- if semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion }}
             pathType: Prefix
             {{- end }}
@@ -69,8 +75,12 @@ spec:
               serviceName: {{ include "devlake.fullname" . }}-grafana
               servicePort: 3000
               {{- end }}
-            {{- end }}
+          {{- end }}
+          {{- if .Values.ingress.useDefaultNginx }}
           - path: /{{ include "devlake.uiEndpointPrefix" . }}(/?|$)(.*)
+          {{- else }}
+          - path: /{{ include "devlake.uiEndpointPrefix" . }}
+          {{- end}}
             {{- if semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion }}
             pathType: Prefix
             {{- end }}
@@ -85,7 +95,7 @@ spec:
               servicePort: 4000
               {{- end }}
 
-{{- if .Values.grafana.useExternal }}
+{{- if and .Values.ingress.useDefaultNginx .Values.grafana.useExternal }}
 ---
 {{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1

--- a/charts/devlake/values.yaml
+++ b/charts/devlake/values.yaml
@@ -116,6 +116,9 @@ grafana:
     repository: apache/devlake-dashboard
     pullPolicy: Always
 
+  # If true, the default Nginx configuration will support a permanent redirect
+  # in the tool's menu. Should you use a different ingress controller, you'll need
+  # to add the ingress with the permanent redirect.
   useExternal: false
 
   externalUrl: ''
@@ -196,6 +199,9 @@ ingress:
   enabled: false
   enableHttps: false
   className: ""
+  # Set to false if you want to use a different ingress controller
+  useDefaultNginx: true
+  # Add annotations required for your ingress controller. Uncomment for Nginx.
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"


### PR DESCRIPTION
If `.Values.ingress.useDefaultNginx` is false, then the Nginx-specific parts of the code are removed, and you're left with a generic ingress. This value is true by default.
If `.Values.grafana.useExternal` and `.Values.ingress.useDefaultNginx` are true, then it creates an Nginx redirect ingress.