### PR TITLE
fix: repair comment error.

### DIFF
--- a/charts/devlake/values.yaml
+++ b/charts/devlake/values.yaml
@@ -39,7 +39,7 @@ mysql:
   # the database for devlake
   database: lake
 
-  # root password for mysql, only used when use_external=true
+  # root password for mysql, only used when use_external=false
   rootPassword: admin
 
   # storage for mysql


### PR DESCRIPTION
When using the MySQL prepared by DevLake, you can specify a root password to manage the MySQL.

@klesh @matrixji Please take a look. cc @JorgeGar @hezyin 