### PR TITLE
chore: avoid sending notification to dev@devlake.apache.org

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -40,3 +40,8 @@ github:
         required_approving_review_count: 1
   collaborators:
     - daniel-hutao
+    
+notifications:
+  commits: commits@devlake.apache.org
+  issues:  commits@devlake.apache.org
+  pullrequests: commits@devlake.apache.org


### PR DESCRIPTION
I get a lot of duplicate emails from Github(notification@github.com) and ASF mailing list (dev@devlake.apache.org) of the repo which is confusing and unnecessary.

![image](https://user-images.githubusercontent.com/61080/233249174-d03bec20-cd71-4667-ae43-a817d4c1f93d.png)

![image](https://user-images.githubusercontent.com/61080/233249211-5884908e-38b3-4569-a5af-98e86f4302d4.png)


This PR redirects commits/issues/prs notifications sent by ASF to another mailing list commits@devlake.apache.org to avoid the duplication.