### PR TITLE
Feat: include security context

### DIFF
--- a/HelmSetup.md
+++ b/HelmSetup.md
@@ -128,10 +128,16 @@ Some useful parameters for the chart, you could also check them in values.yaml
 | mysql.image.repository            | repository for mysql's image                             | mysql                      |
 | mysql.image.tag                   | image tag for mysql's image                              | 8                          |
 | mysql.image.pullPolicy            | pullPolicy for mysql's image                             | IfNotPresent               |
+| mysql.extraLabels                 | extra labels for mysql's statefulset                     | {}                         |
+| mysql.securityContext             | pod security context values                              | {}                         |
+| mysql.containerSecurityContext    | container security context values                        | {}                         |
 | grafana.image.repository          | repository for grafana's image                           | apache/devlake-dashboard   |
 | grafana.image.pullPolicy          | pullPolicy for grafana's image                           | Always                     |
 | grafana.useExternal               | If use external grafana server                           | false                      |
 | grafana.externalUrl               | external grafana server if use external                  | ""                         |
+| grafana.extraLabels               | extra labels for grafana's statefulset                   | {}                         |
+| grafana.securityContext           | pod security context values                              | {}                         |
+| grafana.containerSecurityContext  | container security context values                        | {}                         |
 | lake.storage.class                | storage class for lake's volume                          | ""                         |
 | lake.storage.size                 | volume size for lake's data                              | 100Mi                      |
 | lake.image.repository             | repository for lake's image                              | apache/devlake             |
@@ -139,6 +145,9 @@ Some useful parameters for the chart, you could also check them in values.yaml
 | lake.loggingDir                   | log dir for the lake server                              | /app/logs                  |
 | lake.loggingLevel                 | log level for the lake server                            | info                       |
 | lake.dotenv                       | initial configurations for injecting to lake's .env      | see Values.yaml            |
+| lake.extraLabels                  | extra labels for lake's statefulset                      | {}                         |
+| lake.securityContext              | pod security context values                              | {}                         |
+| lake.containerSecurityContext     | container security context values                        | {}                         |
 | ui.image.repository               | repository for ui's image                                | apache/devlake-config-ui   |
 | ui.image.pullPolicy               | pullPolicy for ui's image                                | Always                     |
 | ui.basicAuth.enabled              | If the basic auth in ui is enabled                       | false                      |
@@ -147,6 +156,9 @@ Some useful parameters for the chart, you could also check them in values.yaml
 | ui.basicAuth.useSecret            | If use secret instead of configmap for basic auth        | false                      |
 | ui.basicAuth.autoCreateSecret     | If let the helm chart create the secret                  | true                       |
 | ui.basicAuth.secretName           | The basic auth secret name                               | devlake-auth               |
+| ui.extraLabels                    | extra labels for ui's statefulset                        | {}                         |
+| ui.securityContext                | pod security context values                              | {}                         |
+| ui.containerSecurityContext       | container security context values                        | {}                         |
 | service.type                      | Service type for exposed service                         | NodePort                   |
 | service.uiPort                    | Node port for config ui                                  | 32001                      |
 | service.ingress.enabled           | If enable ingress                                        | false                      |

--- a/charts/devlake/templates/deployments.yaml
+++ b/charts/devlake/templates/deployments.yaml
@@ -34,9 +34,20 @@ spec:
       labels:
         {{- include "devlake.selectorLabels" . | nindent 8 }}
         devlakeComponent: grafana
+        {{- with .Values.grafana.extraLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
+      {{- with .Values.grafana.securityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       initContainers:
         {{- include "common.initContainerWaitDatabase" . | nindent 8 }}
+          {{- with .Values.grafana.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
       containers:
         - name: grafana
           image: "{{ .Values.grafana.image.repository }}:{{ .Values.imageTag }}"
@@ -72,6 +83,10 @@ spec:
               value: {{ include "mysql.server" . }}:{{ include "mysql.port" . }}
           {{- with .Values.grafana.resources }}
           resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.grafana.containerSecurityContext }}
+          securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
       {{- with .Values.grafana.nodeSelector }}
@@ -115,7 +130,14 @@ spec:
       labels:
         {{- include "devlake.selectorLabels" . | nindent 8 }}
         devlakeComponent: ui
+        {{- with .Values.ui.extraLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
+      {{- with .Values.ui.securityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: config-ui
           image: "{{ .Values.ui.image.repository }}:{{ .Values.imageTag }}"
@@ -150,6 +172,10 @@ spec:
             {{- end }}
           {{- with .Values.ui.resources }}
           resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.ui.containerSecurityContext }}
+          securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
       {{- with .Values.ui.nodeSelector }}

--- a/charts/devlake/templates/secrets.yaml
+++ b/charts/devlake/templates/secrets.yaml
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# TEST
 {{- if and .Values.option.useConnectionDetailsSecret .Values.option.autoCreateSecret }}
 ---
 apiVersion: v1

--- a/charts/devlake/templates/statefulsets.yaml
+++ b/charts/devlake/templates/statefulsets.yaml
@@ -35,7 +35,14 @@ spec:
       labels:
         {{- include "devlake.selectorLabels" . | nindent 8 }}
         devlakeComponent: mysql
+        {{- with .Values.mysql.extraLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
+      {{- with .Values.mysql.securityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: mysql
           image: "{{ .Values.mysql.image.repository }}:{{ .Values.mysql.image.tag }}"
@@ -84,6 +91,10 @@ spec:
               mountPath: /etc/localtime
               readOnly: true
             {{- end }}
+          {{- with .Values.mysql.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
       {{- with .Values.mysql.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -134,7 +145,14 @@ spec:
 #      labels:
 #        {{- include "devlake.selectorLabels" . | nindent 8 }}
 #        devlakeComponent: pgsql
+#          {{- with .Values.pgsql.extraLabels }}
+#          {{- toYaml . | nindent 8 }}
+#          {{- end }}
 #    spec:
+#      {{- with .Values.pgsql.securityContext }}
+#      securityContext:
+#        {{- toYaml . | nindent 8 }}
+#      {{- end }}
 #      containers:
 #        - name: pgsql
 #          image: "{{ .Values.pgsql.image.repository }}:{{ .Values.pgsql.image.tag }}"
@@ -178,6 +196,10 @@ spec:
 #              mountPath: /etc/localtime
 #              readOnly: true
 #            {{- end }}
+#          {{- with .Values.pgsql.containerSecurityContext }}
+#          securityContext:
+#            {{- toYaml . | nindent 12 }}
+#          {{- end }}
 #      {{- with .Values.pgsql.nodeSelector }}
 #      nodeSelector:
 #        {{- toYaml . | nindent 8 }}
@@ -230,12 +252,23 @@ spec:
       labels:
         {{- include "devlake.selectorLabels" . | nindent 8 }}
         devlakeComponent: lake
+        {{- with .Values.lake.extraLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       annotations:
         # Force reload on config changes
         checksum/devlake-config: {{ include (print $.Template.BasePath "/configmaps.yaml") . | sha256sum }}
     spec:
+      {{- with .Values.lake.securityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       initContainers:
         {{- include "common.initContainerWaitDatabase" . | nindent 8 }}
+          {{- with .Values.lake.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
         - name: patch-env
           image: "{{ .Values.alpine.image.repository }}:{{ .Values.alpine.image.tag }}"
           imagePullPolicy: {{ .Values.alpine.image.pullPolicy }}
@@ -261,6 +294,10 @@ spec:
           volumeMounts:
             - mountPath: /app/config
               name: {{ include "devlake.fullname" . }}-lake-config
+          {{- with .Values.lake.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
       containers:
         - name: lake
           image: "{{ .Values.lake.image.repository }}:{{ .Values.imageTag }}"
@@ -294,6 +331,10 @@ spec:
             {{- end }}
           {{- with .Values.lake.resources }}
           resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.lake.containerSecurityContext }}
+          securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
       {{- if .Values.lake.hostNetwork }}

--- a/charts/devlake/values.yaml
+++ b/charts/devlake/values.yaml
@@ -65,6 +65,12 @@ mysql:
 
   # affinity config for mysql if have
   affinity: {}
+  
+  extraLabels: {}
+
+  securityContext: {}
+
+  containerSecurityContext: {}
 
 # pgsql:
 #  # if use external pgsql server, please set true
@@ -108,6 +114,12 @@ mysql:
 #
 #  # affinity config for pgsql if have
 #  affinity: {}
+#  
+#  extraLabels: {}
+#
+#  securityContext: {}
+#
+#  containerSecurityContext: {}
 
 grafana:
   # image for grafana
@@ -129,6 +141,13 @@ grafana:
   tolerations: []
 
   affinity: {}
+  
+  extraLabels: {}
+
+  securityContext: {}
+
+  containerSecurityContext: {}
+  
 
 
 lake:
@@ -162,6 +181,12 @@ lake:
   # debug, info, warn, error
   loggingLevel: "info"
 
+  extraLabels: {}
+
+  securityContext: {}
+
+  containerSecurityContext: {}
+
 ui:
   image:
     repository: apache/devlake-config-ui
@@ -182,6 +207,12 @@ ui:
     useSecret: false
     autoCreateSecret: true
     secretName: devlake-auth
+  
+  extraLabels: {}
+
+  securityContext: {}
+
+  containerSecurityContext: {}
 
 
 # alpine image for some init containers

--- a/charts/devlake/values.yaml
+++ b/charts/devlake/values.yaml
@@ -210,9 +210,22 @@ ui:
   
   extraLabels: {}
 
+  ## SecurityContext holds pod-level security attributes and common container settings.
+  ## This defaults to non root user with uid 101 and gid 1000. *v1.PodSecurityContext  false
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
   securityContext: {}
+    # fsGroup: 101
+    # runAsGroup: 1000
+    # runAsNonRoot: true
+    # runAsUser: 101
 
+  ## K8s containers' Security Context
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
   containerSecurityContext: {}
+    # allowPrivilegeEscalation: false
+    # capabilities:
+    #   drop: 
+    #       - all
 
 
 # alpine image for some init containers


### PR DESCRIPTION
This pull request allows adding **security context** to both pod and containers in all the deployments/statefulsets. 
@matrixji @klesh @IronCore864 Kindly take a look :)