### PR TITLE
feat: use Scarf Gateway for DevLake helm charts downloads

### DIFF
--- a/charts/devlake/values.yaml
+++ b/charts/devlake/values.yaml
@@ -157,7 +157,7 @@ grafana:
 
 lake:
   image:
-    repository: apache/devlake
+    repository: devlake.docker.scarf.sh/apache/devlake
     pullPolicy: Always
     # defaults to imageTag; if set, lake.image.tag will override imageTag
     # tag:
@@ -207,7 +207,7 @@ lake:
 
 ui:
   image:
-    repository: apache/devlake-config-ui
+    repository: devlake.docker.scarf.sh/apache/devlake-config-ui
     pullPolicy: Always
     # defaults to imageTag; if set, lake.image.tag will override imageTag
     # tag:


### PR DESCRIPTION
This PR updates the DevLake helm charts configuration to fetch DevLake containers via a Scarf endpoint, so that DevLake maintainers can collect basic de-identified download and adoption metrics. It does not affect where the containers are being hosted, as Scarf is only redirecting traffic back to Docker Hub.

This change was suggested by DevLake maintainers in direct discussions. We have a separate PR up for the DevLake Docker Compose setup.