### PR TITLE
fix: Use devlake.fullname in dashboard configmaps

### DIFF
--- a/charts/devlake/templates/grafana-dashboard-configmaps/bitbucket.yaml
+++ b/charts/devlake/templates/grafana-dashboard-configmaps/bitbucket.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: bitbucket-dashboard-cm
+  name: {{ include "devlake.fullname" . }}-bitbucket-dashboard-cm
   labels:
     {{ $.Values.grafana.sidecar.dashboards.label }}: {{ $.Values.grafana.sidecar.dashboards.labelValue | quote }}
 data:

--- a/charts/devlake/templates/grafana-dashboard-configmaps/componentandfilelevelmetrics.yaml
+++ b/charts/devlake/templates/grafana-dashboard-configmaps/componentandfilelevelmetrics.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: componentandfilelevelmetrics-dashboard-cm
+  name: {{ include "devlake.fullname" . }}-componentandfilelevelmetrics-dashboard-cm
   labels:
     {{ $.Values.grafana.sidecar.dashboards.label }}: {{ $.Values.grafana.sidecar.dashboards.labelValue | quote }}
 data:

--- a/charts/devlake/templates/grafana-dashboard-configmaps/contributorexperience.yaml
+++ b/charts/devlake/templates/grafana-dashboard-configmaps/contributorexperience.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: contributorexperience-dashboard-cm
+  name: {{ include "devlake.fullname" . }}-contributorexperience-dashboard-cm
   labels:
     {{ $.Values.grafana.sidecar.dashboards.label }}: {{ $.Values.grafana.sidecar.dashboards.labelValue | quote }}
 data:

--- a/charts/devlake/templates/grafana-dashboard-configmaps/demoaveragerequirementleadtimebyassignee.yaml
+++ b/charts/devlake/templates/grafana-dashboard-configmaps/demoaveragerequirementleadtimebyassignee.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: demoaveragerequirementleadtimebyassignee-dashboard-cm
+  name: {{ include "devlake.fullname" . }}-demoaveragerequirementleadtimebyassignee-dashboard-cm
   labels:
     {{ $.Values.grafana.sidecar.dashboards.label }}: {{ $.Values.grafana.sidecar.dashboards.labelValue | quote }}
 data:

--- a/charts/devlake/templates/grafana-dashboard-configmaps/democommitcountbyauthor.yaml
+++ b/charts/devlake/templates/grafana-dashboard-configmaps/democommitcountbyauthor.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: democommitcountbyauthor-dashboard-cm
+  name: {{ include "devlake.fullname" . }}-democommitcountbyauthor-dashboard-cm
   labels:
     {{ $.Values.grafana.sidecar.dashboards.label }}: {{ $.Values.grafana.sidecar.dashboards.labelValue | quote }}
 data:

--- a/charts/devlake/templates/grafana-dashboard-configmaps/demodetailedbuginfo.yaml
+++ b/charts/devlake/templates/grafana-dashboard-configmaps/demodetailedbuginfo.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: demodetailedbuginfo-dashboard-cm
+  name: {{ include "devlake.fullname" . }}-demodetailedbuginfo-dashboard-cm
   labels:
     {{ $.Values.grafana.sidecar.dashboards.label }}: {{ $.Values.grafana.sidecar.dashboards.labelValue | quote }}
 data:

--- a/charts/devlake/templates/grafana-dashboard-configmaps/demohomepage.yaml
+++ b/charts/devlake/templates/grafana-dashboard-configmaps/demohomepage.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: demohomepage-dashboard-cm
+  name: {{ include "devlake.fullname" . }}-demohomepage-dashboard-cm
   labels:
     {{ $.Values.grafana.sidecar.dashboards.label }}: {{ $.Values.grafana.sidecar.dashboards.labelValue | quote }}
 data:

--- a/charts/devlake/templates/grafana-dashboard-configmaps/demohowfastdowerespondtocustomerrequirements.yaml
+++ b/charts/devlake/templates/grafana-dashboard-configmaps/demohowfastdowerespondtocustomerrequirements.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: demohowfastdowerespondtocustomerrequirements-dashboard-cm
+  name: {{ include "devlake.fullname" . }}-demohowfastdowerespondtocustomerrequirements-dashboard-cm
   labels:
     {{ $.Values.grafana.sidecar.dashboards.label }}: {{ $.Values.grafana.sidecar.dashboards.labelValue | quote }}
 data:

--- a/charts/devlake/templates/grafana-dashboard-configmaps/demoisthismonthmoreproductivethanlast.yaml
+++ b/charts/devlake/templates/grafana-dashboard-configmaps/demoisthismonthmoreproductivethanlast.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: demoisthismonthmoreproductivethanlast-dashboard-cm
+  name: {{ include "devlake.fullname" . }}-demoisthismonthmoreproductivethanlast-dashboard-cm
   labels:
     {{ $.Values.grafana.sidecar.dashboards.label }}: {{ $.Values.grafana.sidecar.dashboards.labelValue | quote }}
 data:

--- a/charts/devlake/templates/grafana-dashboard-configmaps/demowasourqualityimprovedornot.yaml
+++ b/charts/devlake/templates/grafana-dashboard-configmaps/demowasourqualityimprovedornot.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: demowasourqualityimprovedornot-dashboard-cm
+  name: {{ include "devlake.fullname" . }}-demowasourqualityimprovedornot-dashboard-cm
   labels:
     {{ $.Values.grafana.sidecar.dashboards.label }}: {{ $.Values.grafana.sidecar.dashboards.labelValue | quote }}
 data:

--- a/charts/devlake/templates/grafana-dashboard-configmaps/dora.yaml
+++ b/charts/devlake/templates/grafana-dashboard-configmaps/dora.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: dora-dashboard-cm
+  name: {{ include "devlake.fullname" . }}-dora-dashboard-cm
   labels:
     {{ $.Values.grafana.sidecar.dashboards.label }}: {{ $.Values.grafana.sidecar.dashboards.labelValue | quote }}
 data:

--- a/charts/devlake/templates/grafana-dashboard-configmaps/dorabyteam.yaml
+++ b/charts/devlake/templates/grafana-dashboard-configmaps/dorabyteam.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: dorabyteam-dashboard-cm
+  name: {{ include "devlake.fullname" . }}-dorabyteam-dashboard-cm
   labels:
     {{ $.Values.grafana.sidecar.dashboards.label }}: {{ $.Values.grafana.sidecar.dashboards.labelValue | quote }}
 data:

--- a/charts/devlake/templates/grafana-dashboard-configmaps/doradebug.yaml
+++ b/charts/devlake/templates/grafana-dashboard-configmaps/doradebug.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: doradebug-dashboard-cm
+  name: {{ include "devlake.fullname" . }}-doradebug-dashboard-cm
   labels:
     {{ $.Values.grafana.sidecar.dashboards.label }}: {{ $.Values.grafana.sidecar.dashboards.labelValue | quote }}
 data:

--- a/charts/devlake/templates/grafana-dashboard-configmaps/engineeringoverview.yaml
+++ b/charts/devlake/templates/grafana-dashboard-configmaps/engineeringoverview.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: engineeringoverview-dashboard-cm
+  name: {{ include "devlake.fullname" . }}-engineeringoverview-dashboard-cm
   labels:
     {{ $.Values.grafana.sidecar.dashboards.label }}: {{ $.Values.grafana.sidecar.dashboards.labelValue | quote }}
 data:

--- a/charts/devlake/templates/grafana-dashboard-configmaps/engineeringthroughputandcycletime.yaml
+++ b/charts/devlake/templates/grafana-dashboard-configmaps/engineeringthroughputandcycletime.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: engineeringthroughputandcycletime-dashboard-cm
+  name: {{ include "devlake.fullname" . }}-engineeringthroughputandcycletime-dashboard-cm
   labels:
     {{ $.Values.grafana.sidecar.dashboards.label }}: {{ $.Values.grafana.sidecar.dashboards.labelValue | quote }}
 data:

--- a/charts/devlake/templates/grafana-dashboard-configmaps/engineeringthroughputandcycletimeteamview.yaml
+++ b/charts/devlake/templates/grafana-dashboard-configmaps/engineeringthroughputandcycletimeteamview.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: engineeringthroughputandcycletimeteamview-dashboard-cm
+  name: {{ include "devlake.fullname" . }}-engineeringthroughputandcycletimeteamview-dashboard-cm
   labels:
     {{ $.Values.grafana.sidecar.dashboards.label }}: {{ $.Values.grafana.sidecar.dashboards.labelValue | quote }}
 data:

--- a/charts/devlake/templates/grafana-dashboard-configmaps/github.yaml
+++ b/charts/devlake/templates/grafana-dashboard-configmaps/github.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: github-dashboard-cm
+  name: {{ include "devlake.fullname" . }}-github-dashboard-cm
   labels:
     {{ $.Values.grafana.sidecar.dashboards.label }}: {{ $.Values.grafana.sidecar.dashboards.labelValue | quote }}
 data:

--- a/charts/devlake/templates/grafana-dashboard-configmaps/githubreleasequalityandcontributionanalysis.yaml
+++ b/charts/devlake/templates/grafana-dashboard-configmaps/githubreleasequalityandcontributionanalysis.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: githubreleasequalityandcontributionanalysis-dashboard-cm
+  name: {{ include "devlake.fullname" . }}-githubreleasequalityandcontributionanalysis-dashboard-cm
   labels:
     {{ $.Values.grafana.sidecar.dashboards.label }}: {{ $.Values.grafana.sidecar.dashboards.labelValue | quote }}
 data:

--- a/charts/devlake/templates/grafana-dashboard-configmaps/gitlab.yaml
+++ b/charts/devlake/templates/grafana-dashboard-configmaps/gitlab.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: gitlab-dashboard-cm
+  name: {{ include "devlake.fullname" . }}-gitlab-dashboard-cm
   labels:
     {{ $.Values.grafana.sidecar.dashboards.label }}: {{ $.Values.grafana.sidecar.dashboards.labelValue | quote }}
 data:

--- a/charts/devlake/templates/grafana-dashboard-configmaps/homepage.yaml
+++ b/charts/devlake/templates/grafana-dashboard-configmaps/homepage.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: homepage-dashboard-cm
+  name: {{ include "devlake.fullname" . }}-homepage-dashboard-cm
   labels:
     {{ $.Values.grafana.sidecar.dashboards.label }}: {{ $.Values.grafana.sidecar.dashboards.labelValue | quote }}
 data:

--- a/charts/devlake/templates/grafana-dashboard-configmaps/jenkins.yaml
+++ b/charts/devlake/templates/grafana-dashboard-configmaps/jenkins.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: jenkins-dashboard-cm
+  name: {{ include "devlake.fullname" . }}-jenkins-dashboard-cm
   labels:
     {{ $.Values.grafana.sidecar.dashboards.label }}: {{ $.Values.grafana.sidecar.dashboards.labelValue | quote }}
 data:

--- a/charts/devlake/templates/grafana-dashboard-configmaps/jira.yaml
+++ b/charts/devlake/templates/grafana-dashboard-configmaps/jira.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: jira-dashboard-cm
+  name: {{ include "devlake.fullname" . }}-jira-dashboard-cm
   labels:
     {{ $.Values.grafana.sidecar.dashboards.label }}: {{ $.Values.grafana.sidecar.dashboards.labelValue | quote }}
 data:

--- a/charts/devlake/templates/grafana-dashboard-configmaps/sonarqube.yaml
+++ b/charts/devlake/templates/grafana-dashboard-configmaps/sonarqube.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: sonarqube-dashboard-cm
+  name: {{ include "devlake.fullname" . }}-sonarqube-dashboard-cm
   labels:
     {{ $.Values.grafana.sidecar.dashboards.label }}: {{ $.Values.grafana.sidecar.dashboards.labelValue | quote }}
 data:

--- a/charts/devlake/templates/grafana-dashboard-configmaps/tapd.yaml
+++ b/charts/devlake/templates/grafana-dashboard-configmaps/tapd.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: tapd-dashboard-cm
+  name: {{ include "devlake.fullname" . }}-tapd-dashboard-cm
   labels:
     {{ $.Values.grafana.sidecar.dashboards.label }}: {{ $.Values.grafana.sidecar.dashboards.labelValue | quote }}
 data:

--- a/charts/devlake/templates/grafana-dashboard-configmaps/teambition.yaml
+++ b/charts/devlake/templates/grafana-dashboard-configmaps/teambition.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: teambition-dashboard-cm
+  name: {{ include "devlake.fullname" . }}-teambition-dashboard-cm
   labels:
     {{ $.Values.grafana.sidecar.dashboards.label }}: {{ $.Values.grafana.sidecar.dashboards.labelValue | quote }}
 data:

--- a/charts/devlake/templates/grafana-dashboard-configmaps/weeklybugretro.yaml
+++ b/charts/devlake/templates/grafana-dashboard-configmaps/weeklybugretro.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: weeklybugretro-dashboard-cm
+  name: {{ include "devlake.fullname" . }}-weeklybugretro-dashboard-cm
   labels:
     {{ $.Values.grafana.sidecar.dashboards.label }}: {{ $.Values.grafana.sidecar.dashboards.labelValue | quote }}
 data:

--- a/charts/devlake/templates/grafana-dashboard-configmaps/weeklycommunityretro.yaml
+++ b/charts/devlake/templates/grafana-dashboard-configmaps/weeklycommunityretro.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: weeklycommunityretro-dashboard-cm
+  name: {{ include "devlake.fullname" . }}-weeklycommunityretro-dashboard-cm
   labels:
     {{ $.Values.grafana.sidecar.dashboards.label }}: {{ $.Values.grafana.sidecar.dashboards.labelValue | quote }}
 data:

--- a/charts/devlake/templates/grafana-dashboard-configmaps/zentao.yaml
+++ b/charts/devlake/templates/grafana-dashboard-configmaps/zentao.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: zentao-dashboard-cm
+  name: {{ include "devlake.fullname" . }}-zentao-dashboard-cm
   labels:
     {{ $.Values.grafana.sidecar.dashboards.label }}: {{ $.Values.grafana.sidecar.dashboards.labelValue | quote }}
 data:


### PR DESCRIPTION
Otherwise the configmap cause conflicts if multiple chart releases are installed in the same kubernetes namespace.