### PR TITLE
adding ability to leverage basic annotations

### DIFF
--- a/charts/devlake/templates/deployments.yaml
+++ b/charts/devlake/templates/deployments.yaml
@@ -36,7 +36,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
       annotations:
-        {{- toYaml .Values.ui.annotations | nindent 8 }}
+        {{- toYaml .Values.ui.podAnnotations | nindent 8 }}
     spec:
       {{- with .Values.ui.securityContext }}
       securityContext:
@@ -116,7 +116,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       annotations:
-        {{- toYaml .Values.lake.annotations | nindent 8 }}
+        {{- toYaml .Values.lake.podAnnotations | nindent 8 }}
     spec:
       {{- with .Values.lake.securityContext }}
       securityContext:

--- a/charts/devlake/templates/deployments.yaml
+++ b/charts/devlake/templates/deployments.yaml
@@ -35,6 +35,8 @@ spec:
         {{- with .Values.ui.extraLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
+      annotations:
+        {{- toYaml .Values.ui.annotations | nindent 8 }}
     spec:
       {{- with .Values.ui.securityContext }}
       securityContext:
@@ -113,6 +115,8 @@ spec:
         {{- with .Values.lake.extraLabels }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      annotations:
+        {{- toYaml .Values.lake.annotations | nindent 8 }}
     spec:
       {{- with .Values.lake.securityContext }}
       securityContext:

--- a/charts/devlake/templates/statefulsets.yaml
+++ b/charts/devlake/templates/statefulsets.yaml
@@ -38,6 +38,8 @@ spec:
         {{- with .Values.mysql.extraLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
+      annotations:
+        {{- toYaml .Values.mysql.annotations | nindent 8 }}
     spec:
       {{- with .Values.mysql.securityContext }}
       securityContext:

--- a/charts/devlake/templates/statefulsets.yaml
+++ b/charts/devlake/templates/statefulsets.yaml
@@ -39,7 +39,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
       annotations:
-        {{- toYaml .Values.mysql.annotations | nindent 8 }}
+        {{- toYaml .Values.mysql.podAnnotations | nindent 8 }}
     spec:
       {{- with .Values.mysql.securityContext }}
       securityContext:

--- a/charts/devlake/values.yaml
+++ b/charts/devlake/values.yaml
@@ -82,6 +82,8 @@ mysql:
 
   containerSecurityContext: {}
 
+  annotations: {}
+
   service:
     type: "ClusterIP"
     nodePort: ""
@@ -134,6 +136,8 @@ mysql:
 #   securityContext: {}
 
 #   containerSecurityContext: {}
+
+#   annotations: {}
 
 # dependency chart values
 grafana:
@@ -200,6 +204,8 @@ lake:
 
   containerSecurityContext: {}
 
+  annotations: {}
+
 ui:
   image:
     repository: devlake.docker.scarf.sh/apache/devlake-config-ui
@@ -222,6 +228,8 @@ ui:
     secretName: ""
 
   extraLabels: {}
+
+  annotations: {}
 
   ## SecurityContext holds pod-level security attributes and common container settings.
   ## This defaults to non root user with uid 101 and gid 1000. *v1.PodSecurityContext  false

--- a/charts/devlake/values.yaml
+++ b/charts/devlake/values.yaml
@@ -82,7 +82,7 @@ mysql:
 
   containerSecurityContext: {}
 
-  annotations: {}
+  podAnnotations: {}
 
   service:
     type: "ClusterIP"
@@ -204,7 +204,7 @@ lake:
 
   containerSecurityContext: {}
 
-  annotations: {}
+  podAnnotations: {}
 
 ui:
   image:
@@ -229,7 +229,7 @@ ui:
 
   extraLabels: {}
 
-  annotations: {}
+  podAnnotations: {}
 
   ## SecurityContext holds pod-level security attributes and common container settings.
   ## This defaults to non root user with uid 101 and gid 1000. *v1.PodSecurityContext  false


### PR DESCRIPTION
Hi!

My team has recently adopted `devlake` and have found ourselves unable to monitor the kubernetes resources effectively without annotations.  So that's what this pull request is intended to add.

