### PR TITLE
fix: Grafana ingress and containerSecurity

### DIFF
--- a/charts/devlake/templates/deployments.yaml
+++ b/charts/devlake/templates/deployments.yaml
@@ -121,8 +121,8 @@ spec:
       initContainers:
         {{- include "common.initContainerWaitDatabase" . | nindent 8 }}
         {{- with .Values.lake.containerSecurityContext }}
-        securityContext:
-        {{- toYaml . | nindent 12 }}
+          securityContext:
+          {{- toYaml . | nindent 12 }}
       {{- end }}
       containers:
         - name: lake

--- a/charts/devlake/templates/ingresses.yaml
+++ b/charts/devlake/templates/ingresses.yaml
@@ -67,11 +67,11 @@ spec:
             backend:
               {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
               service:
-                name: {{ include "devlake.fullname" . }}-grafana
+                name: {{ include "grafana.fullname" (dict "Values" .Values.grafana "Chart" (dict "Name" "grafana") "Release" .Release ) }}
                 port:
                   number: {{ .Values.grafana.service.port }}
               {{- else }}
-              serviceName: {{ include "devlake.fullname" . }}-grafana
+              serviceName: {{ include "grafana.fullname" (dict "Values" .Values.grafana "Chart" (dict "Name" "grafana") "Release" .Release ) }}
               servicePort: {{ .Values.grafana.service.port }}
               {{- end }}
           {{- end }}

--- a/charts/devlake/templates/ingresses.yaml
+++ b/charts/devlake/templates/ingresses.yaml
@@ -69,10 +69,10 @@ spec:
               service:
                 name: {{ include "devlake.fullname" . }}-grafana
                 port:
-                  number: 3000
+                  number: {{ .Values.grafana.service.port }}
               {{- else }}
               serviceName: {{ include "devlake.fullname" . }}-grafana
-              servicePort: 3000
+              servicePort: {{ .Values.grafana.service.port }}
               {{- end }}
           {{- end }}
           {{- if .Values.ingress.useDefaultNginx }}


### PR DESCRIPTION
Two issues I ran into while using the chart

- Ingress backend service for `grafana` is misconfigured, both name and port
  #160
- Unable to set `containerSecurityContext` for `devlake-backend` due to indentation problem