### PR TITLE
Replace submodules by GitHub actions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,7 +35,7 @@ jobs:
           helm repo add grafana https://grafana.github.io/helm-charts
 
       - name: Run chart-releaser
-        uses: ./.github/actions/chart-releaser-action
+        uses: helm/chart-releaser-action@v1.6.0
         with:
           charts_dir: charts
         env:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,0 @@
-[submodule ".github/actions/setup-kind"]
-	path = .github/actions/setup-kind
-	url = https://github.com/engineerd/setup-kind.git
-	branch = v0.5.0
-[submodule ".github/actions/chart-releaser-action"]
-	path = .github/actions/chart-releaser-action
-	url = git@github.com:helm/chart-releaser-action.git


### PR DESCRIPTION
Currently `Helm release` builds are [failing](https://github.com/apache/incubator-devlake-helm-chart/actions/runs/6862648484) due to submodules problems

This PR addresses this by replacing the submodules by direct action references