### PR TITLE
fix: No point having to use tpl for map iterations

### DIFF
--- a/charts/devlake/templates/deployments.yaml
+++ b/charts/devlake/templates/deployments.yaml
@@ -158,12 +158,12 @@ spec:
             - name: PORT
               value: "{{ .Values.lake.port }}"
             {{- range $key1, $value1 := .Values.lake.envs }}
-            - name: "{{ tpl $key1 $ }}"
-              value: "{{ tpl (print $value1) $ }}"
+            - name: "{{ $key1 }}"
+              value: "{{ $value1 }}"
             {{- end }}
             {{- range $key2, $value2 := .Values.commonEnvs }}
-            - name: "{{ tpl $key2 $ }}"
-              value: "{{ tpl (print $value2) $ }}"
+            - name: "{{ $key2 }}"
+              value: "{{ $value2 }}"
             {{- end }}
           {{- with .Values.lake.resources }}
           resources:


### PR DESCRIPTION
So we have an issue where we are getting the following error:

```
template: devlake/templates/deployments.yaml:161:29: executing "devlake/templates/deployments.yaml" at <$key1>: wrong type for value; expected string; got int
```

There isn't a need to wrap the keys and values via `tpl`, when they can inferred statically. This should resolve the issue reported above.