### PR TITLE
feat: add additional deployment metadata labels

### DIFF
--- a/HelmSetup.md
+++ b/HelmSetup.md
@@ -176,11 +176,12 @@ Some useful parameters for the chart, you could also check them in values.yaml
 | lake.encryptionSecret.secretName          | the k8s secret name for ENCRYPTION_SECRET                                             | ""                       |
 | lake.encryptionSecret.secret              | the secret for ENCRYPTION_SECRET                                                      | ""                       |
 | lake.encryptionSecret.autoCreateSecret    | whether let the helm chart create the secret                                          | true                     |
-| lake.extraLabels                          | extra labels for lake's statefulset                                                   | {}                       |
+| lake.extraLabels                          | extra labels for lake's deployment template                                           | {}                       |
 | lake.securityContext                      | pod security context values                                                           | {}                       |
 | lake.containerSecurityContext             | container security context values                                                     | {}                       |
 | lake.livenessProbe                        | container livenessprobe                                                               | see Values.yaml          |
 | lake.readinessProbe                       | container readinessProbe                                                              | {}                       |
+| lake.deployment.extraLabels               | extra labels for lake's deployment metadata                                           | {}                       |
 | ui.image.repository                       | repository for ui's image                                                             | apache/devlake-config-ui |
 | ui.image.pullPolicy                       | pullPolicy for ui's image                                                             | Always                   |
 | ui.basicAuth.enabled                      | If the basic auth in ui is enabled                                                    | false                    |
@@ -188,9 +189,10 @@ Some useful parameters for the chart, you could also check them in values.yaml
 | ui.basicAuth.password                     | The password for the basic auth                                                       | "admin"                  |
 | ui.basicAuth.autoCreateSecret             | If let the helm chart create the secret                                               | true                     |
 | ui.basicAuth.secretName                   | The basic auth secret name                                                            | ""                       |
-| ui.extraLabels                            | extra labels for ui's statefulset                                                     | {}                       |
+| ui.extraLabels                            | extra labels for ui's deployment template                                             | {}                       |
 | ui.securityContext                        | pod security context values                                                           | {}                       |
 | ui.containerSecurityContext               | container security context values                                                     | {}                       |
+| ui.deployment.extraLabels                 | extra labels for ui's deployment metadata                                             | {}                       |
 | service.type                              | Service type for exposed service                                                      | NodePort                 |
 | service.uiPort                            | Node port for config ui                                                               | 32001                    |
 | service.ingress.enabled                   | If enable ingress                                                                     | false                    |

--- a/charts/devlake/templates/deployments.yaml
+++ b/charts/devlake/templates/deployments.yaml
@@ -22,6 +22,9 @@ metadata:
   name: {{ include "devlake.fullname" . }}-ui
   labels:
     {{- include "devlake.labels" . | nindent 4 }}
+    {{- with .Values.ui.deployment.extraLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   replicas: 1
   selector:
@@ -102,6 +105,9 @@ metadata:
   name: {{ include "devlake.fullname" . }}-lake
   labels:
   {{- include "devlake.labels" . | nindent 4 }}
+  {{- with .Values.lake.deployment.extraLabels }}
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   replicas: 1
   selector:

--- a/charts/devlake/values.yaml
+++ b/charts/devlake/values.yaml
@@ -216,6 +216,9 @@ lake:
 
   readinessProbe: {}
 
+  deployment:
+    extraLabels: {}
+
 ui:
   image:
     repository: devlake.docker.scarf.sh/apache/devlake-config-ui
@@ -259,6 +262,9 @@ ui:
     # capabilities:
     #   drop:
     #       - all
+
+  deployment:
+    extraLabels: {}
 
 # alpine image for some init containers
 alpine:


### PR DESCRIPTION
Hey everyone,
my company has some K8s cluster policies in place that require me to set certain metadata labels. So far it's not possible to configure this in the Helm chart. That's why I'd like to propose this change.
Cheers