### PR TITLE
feat: add authorization to health probes

### DIFF
--- a/charts/devlake/templates/_helpers.tpl
+++ b/charts/devlake/templates/_helpers.tpl
@@ -117,6 +117,8 @@ The ui endpoint
   {{- if .enabled -}}
 name: Authorization
 value: {{ printf "Basic %s" (printf "%s:%s" .user .password | b64enc) | quote }}
+  {{- else -}}
+[]
   {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/devlake/templates/_helpers.tpl
+++ b/charts/devlake/templates/_helpers.tpl
@@ -112,6 +112,15 @@ The ui endpoint
 {{- end -}}
 {{- end -}}
 
+{{- define "devlake.ui.auth.probe" -}}
+{{- with .Values.ui.basicAuth }}
+  {{- if .enabled -}}
+name: Authorization
+value: {{ printf "Basic %s" (printf "%s:%s" .user .password | b64enc) | quote }}
+  {{- end }}
+{{- end }}
+{{- end }}
+
 {{- define "devlake.lake.encryption.secret" -}}
 {{- if .Values.lake.encryptionSecret.secretName -}}
 {{- .Values.lake.encryptionSecret.secretName -}}

--- a/charts/devlake/templates/deployments.yaml
+++ b/charts/devlake/templates/deployments.yaml
@@ -56,12 +56,19 @@ spec:
           imagePullPolicy: {{ .Values.ui.image.pullPolicy }}
           ports:
             - containerPort: 4000
+          {{- $httpAuthProbe := (include "devlake.ui.auth.probe" $ | fromYaml | list) }}
           {{- with .Values.ui.livenessProbe }}
           livenessProbe:
+            {{- if not (hasKey .httpGet "httpHeaders") }}
+              {{- $_ := set .httpGet "httpHeaders" ($httpAuthProbe) }}
+            {{- end }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- with .Values.ui.readinessProbe }}
           readinessProbe:
+            {{- if not (hasKey .httpGet "httpHeaders") }}
+              {{- $_ := set .httpGet "httpHeaders" ($httpAuthProbe) }}
+            {{- end }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- if .Values.ui.basicAuth.enabled }}

--- a/charts/devlake/templates/deployments.yaml
+++ b/charts/devlake/templates/deployments.yaml
@@ -57,21 +57,22 @@ spec:
           ports:
             - containerPort: 4000
           {{- $httpAuthProbe := (include "devlake.ui.auth.probe" $ | fromYaml | list) }}
+          {{- $basicAuth := .Values.ui.basicAuth.enabled }}
           {{- with .Values.ui.livenessProbe }}
           livenessProbe:
-            {{- if not (hasKey .httpGet "httpHeaders") }}
+            {{- if and ($basicAuth) (not (hasKey .httpGet "httpHeaders")) }}
               {{- $_ := set .httpGet "httpHeaders" ($httpAuthProbe) }}
             {{- end }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- with .Values.ui.readinessProbe }}
           readinessProbe:
-            {{- if not (hasKey .httpGet "httpHeaders") }}
+            {{- if and ($basicAuth) (not (hasKey .httpGet "httpHeaders")) }}
               {{- $_ := set .httpGet "httpHeaders" ($httpAuthProbe) }}
             {{- end }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- if .Values.ui.basicAuth.enabled }}
+          {{- if $basicAuth }}
           envFrom:
             - secretRef:
                 name: {{ include "devlake.ui.auth.secret" . }}


### PR DESCRIPTION
If setting `.ui.basicAuth.enabled: true`, `ui.readinessProbe` and `ui.livenessProbe` :x: fail because the `httpGet` probe replies with `HTTP 401`.

If no `httpHeaders` are added manually in values (to add `Authorization` header), define them based on the `basicAuth.user` and `basicAuth.password` value.