### PR TITLE
Enabled replicaCount

### DIFF
--- a/charts/devlake/templates/deployments.yaml
+++ b/charts/devlake/templates/deployments.yaml
@@ -26,7 +26,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.replicaCount }}
   {{- with .Values.ui.strategy }}
   strategy:
     {{- toYaml . | nindent 4 }}
@@ -126,7 +126,7 @@ metadata:
   {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  replicas: 1
+  replicas: {{ if gt .Values.replicaCount 1 }}1{{ else }}{{ .Values.replicaCount }}{{ end }}
   {{- with .Values.lake.strategy }}
   strategy:
     {{- toYaml . | nindent 4 }}

--- a/charts/devlake/templates/statefulsets.yaml
+++ b/charts/devlake/templates/statefulsets.yaml
@@ -25,7 +25,7 @@ metadata:
   labels:
     {{- include "devlake.labels" . | nindent 4 }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.replicaCount }}
   serviceName: {{ include "devlake.fullname" . }}-mysql
   selector:
     matchLabels:


### PR DESCRIPTION
Enables the ability to set replicas of StatefulSet and deployments to 0, fully disabling the devlake-helm-chart. This ensures compliance with the requirement of having only one replica for deployments in dev-lake, providing finer control over the development environment.

Issue: https://github.com/apache/incubator-devlake-helm-chart/issues/266