### PR TITLE
Volume mount support and remove init container

### DIFF
--- a/HelmSetup.md
+++ b/HelmSetup.md
@@ -24,7 +24,7 @@ To install the chart with release name `devlake`:
 helm repo add devlake https://apache.github.io/incubator-devlake-helm-chart
 helm repo update
 ENCRYPTION_SECRET=$(openssl rand -base64 2000 | tr -dc 'A-Z' | fold -w 128 | head -n 1)
-helm install devlake devlake/devlake --version=0.19.1-beta3 --set lake.encryptionSecret.secret=$ENCRYPTION_SECRET
+helm install devlake devlake/devlake --version=0.19.0 --set lake.encryptionSecret.secret=$ENCRYPTION_SECRET
 ```
 
 Visit your devlake from the node port (32001 by default): http://YOUR-NODE-IP:32001.
@@ -49,14 +49,14 @@ _Notes for mac users with minikube:_
 
 ```shell
 helm repo update
-helm upgrade devlake devlake/devlake --version=0.19.1-beta3 --set lake.encryptionSecret.secret=<ENCRYPTION_SECRET>
+helm upgrade devlake devlake/devlake --version=0.19.0 --set lake.encryptionSecret.secret=<ENCRYPTION_SECRET>
 ```
 
 **If you're upgrading from DevLake v0.18.x or later versions:**
 
 ```shell
 helm repo update
-helm upgrade devlake devlake/devlake --version=0.19.1-beta3
+helm upgrade devlake devlake/devlake --version=0.19.0
 ```
 
 ### 2.3 Uninstall

--- a/HelmSetup.md
+++ b/HelmSetup.md
@@ -24,7 +24,7 @@ To install the chart with release name `devlake`:
 helm repo add devlake https://apache.github.io/incubator-devlake-helm-chart
 helm repo update
 ENCRYPTION_SECRET=$(openssl rand -base64 2000 | tr -dc 'A-Z' | fold -w 128 | head -n 1)
-helm install devlake devlake/devlake --version=0.19.1-beta1 --set lake.encryptionSecret.secret=$ENCRYPTION_SECRET
+helm install devlake devlake/devlake --version=0.19.1-beta2 --set lake.encryptionSecret.secret=$ENCRYPTION_SECRET
 ```
 
 Visit your devlake from the node port (32001 by default): http://YOUR-NODE-IP:32001.
@@ -49,14 +49,14 @@ _Notes for mac users with minikube:_
 
 ```shell
 helm repo update
-helm upgrade devlake devlake/devlake --version=0.19.1-beta1 --set lake.encryptionSecret.secret=<ENCRYPTION_SECRET>
+helm upgrade devlake devlake/devlake --version=0.19.1-beta2 --set lake.encryptionSecret.secret=<ENCRYPTION_SECRET>
 ```
 
 **If you're upgrading from DevLake v0.18.x or later versions:**
 
 ```shell
 helm repo update
-helm upgrade devlake devlake/devlake --version=0.19.1-beta1
+helm upgrade devlake devlake/devlake --version=0.19.1-beta2
 ```
 
 ### 2.3 Uninstall

--- a/HelmSetup.md
+++ b/HelmSetup.md
@@ -24,7 +24,7 @@ To install the chart with release name `devlake`:
 helm repo add devlake https://apache.github.io/incubator-devlake-helm-chart
 helm repo update
 ENCRYPTION_SECRET=$(openssl rand -base64 2000 | tr -dc 'A-Z' | fold -w 128 | head -n 1)
-helm install devlake devlake/devlake --version=0.19.1-beta2 --set lake.encryptionSecret.secret=$ENCRYPTION_SECRET
+helm install devlake devlake/devlake --version=0.19.1-beta3 --set lake.encryptionSecret.secret=$ENCRYPTION_SECRET
 ```
 
 Visit your devlake from the node port (32001 by default): http://YOUR-NODE-IP:32001.
@@ -49,14 +49,14 @@ _Notes for mac users with minikube:_
 
 ```shell
 helm repo update
-helm upgrade devlake devlake/devlake --version=0.19.1-beta2 --set lake.encryptionSecret.secret=<ENCRYPTION_SECRET>
+helm upgrade devlake devlake/devlake --version=0.19.1-beta3 --set lake.encryptionSecret.secret=<ENCRYPTION_SECRET>
 ```
 
 **If you're upgrading from DevLake v0.18.x or later versions:**
 
 ```shell
 helm repo update
-helm upgrade devlake devlake/devlake --version=0.19.1-beta2
+helm upgrade devlake devlake/devlake --version=0.19.1-beta3
 ```
 
 ### 2.3 Uninstall

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ helm install devlake devlake/devlake --set lake.encryptionSecret.secret=$ENCRYPT
 helm repo add devlake https://apache.github.io/incubator-devlake-helm-chart
 helm repo update
 ENCRYPTION_SECRET=$(openssl rand -base64 2000 | tr -dc 'A-Z' | fold -w 128 | head -n 1)
-helm install devlake devlake/devlake --version=0.19.1-beta1 --set lake.encryptionSecret.secret=$ENCRYPTION_SECRET
+helm install devlake devlake/devlake --version=0.19.1-beta2 --set lake.encryptionSecret.secret=$ENCRYPTION_SECRET
 ```
 
 If you are using minikube inside your mac, please use the following command to forward the port:
@@ -71,14 +71,14 @@ grafana by url `http://YOUR-NODE-IP:30091`
 
 ```shell
 helm repo update
-helm upgrade devlake devlake/devlake --version=0.19.1-beta1 --set lake.encryptionSecret.secret=<ENCRYPTION_SECRET>
+helm upgrade devlake devlake/devlake --version=0.19.1-beta2 --set lake.encryptionSecret.secret=<ENCRYPTION_SECRET>
 ```
 
 **If you're upgrading from DevLake v0.18.x or later versions:**
 
 ```shell
 helm repo update
-helm upgrade devlake devlake/devlake --version=0.19.1-beta1
+helm upgrade devlake devlake/devlake --version=0.19.1-beta2
 ```
 
 ## Uninstall

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ helm install devlake devlake/devlake --set lake.encryptionSecret.secret=$ENCRYPT
 helm repo add devlake https://apache.github.io/incubator-devlake-helm-chart
 helm repo update
 ENCRYPTION_SECRET=$(openssl rand -base64 2000 | tr -dc 'A-Z' | fold -w 128 | head -n 1)
-helm install devlake devlake/devlake --version=0.19.1-beta3 --set lake.encryptionSecret.secret=$ENCRYPTION_SECRET
+helm install devlake devlake/devlake --version=0.19.0 --set lake.encryptionSecret.secret=$ENCRYPTION_SECRET
 ```
 
 If you are using minikube inside your mac, please use the following command to forward the port:
@@ -71,14 +71,14 @@ grafana by url `http://YOUR-NODE-IP:30091`
 
 ```shell
 helm repo update
-helm upgrade devlake devlake/devlake --version=0.19.1-beta3 --set lake.encryptionSecret.secret=<ENCRYPTION_SECRET>
+helm upgrade devlake devlake/devlake --version=0.19.0 --set lake.encryptionSecret.secret=<ENCRYPTION_SECRET>
 ```
 
 **If you're upgrading from DevLake v0.18.x or later versions:**
 
 ```shell
 helm repo update
-helm upgrade devlake devlake/devlake --version=0.19.1-beta3
+helm upgrade devlake devlake/devlake --version=0.19.0
 ```
 
 ## Uninstall

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ helm install devlake devlake/devlake --set lake.encryptionSecret.secret=$ENCRYPT
 helm repo add devlake https://apache.github.io/incubator-devlake-helm-chart
 helm repo update
 ENCRYPTION_SECRET=$(openssl rand -base64 2000 | tr -dc 'A-Z' | fold -w 128 | head -n 1)
-helm install devlake devlake/devlake --version=0.19.1-beta2 --set lake.encryptionSecret.secret=$ENCRYPTION_SECRET
+helm install devlake devlake/devlake --version=0.19.1-beta3 --set lake.encryptionSecret.secret=$ENCRYPTION_SECRET
 ```
 
 If you are using minikube inside your mac, please use the following command to forward the port:
@@ -71,14 +71,14 @@ grafana by url `http://YOUR-NODE-IP:30091`
 
 ```shell
 helm repo update
-helm upgrade devlake devlake/devlake --version=0.19.1-beta2 --set lake.encryptionSecret.secret=<ENCRYPTION_SECRET>
+helm upgrade devlake devlake/devlake --version=0.19.1-beta3 --set lake.encryptionSecret.secret=<ENCRYPTION_SECRET>
 ```
 
 **If you're upgrading from DevLake v0.18.x or later versions:**
 
 ```shell
 helm repo update
-helm upgrade devlake devlake/devlake --version=0.19.1-beta2
+helm upgrade devlake devlake/devlake --version=0.19.1-beta3
 ```
 
 ## Uninstall

--- a/charts/devlake/Chart.yaml
+++ b/charts/devlake/Chart.yaml
@@ -28,10 +28,10 @@ keywords:
 type: application
 
 # Chart version
-version: 0.19.1-beta2
+version: 0.19.1-beta3
 
 # devlake version
-appVersion: v0.19.1-beta2
+appVersion: v0.19.1-beta3
 
 dependencies:
   - condition: grafana.enabled

--- a/charts/devlake/Chart.yaml
+++ b/charts/devlake/Chart.yaml
@@ -28,10 +28,10 @@ keywords:
 type: application
 
 # Chart version
-version: 0.19.1-beta3
+version: 0.19.0
 
 # devlake version
-appVersion: v0.19.1-beta3
+appVersion: v0.19.0
 
 dependencies:
   - condition: grafana.enabled

--- a/charts/devlake/Chart.yaml
+++ b/charts/devlake/Chart.yaml
@@ -28,10 +28,10 @@ keywords:
 type: application
 
 # Chart version
-version: 0.19.1-beta1
+version: 0.19.1-beta2
 
 # devlake version
-appVersion: v0.19.1-beta1
+appVersion: v0.19.1-beta2
 
 dependencies:
   - condition: grafana.enabled

--- a/charts/devlake/templates/deployments.yaml
+++ b/charts/devlake/templates/deployments.yaml
@@ -122,11 +122,13 @@ spec:
       securityContext:
       {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if not .Values.mysql.useExternal }}
       initContainers:
         {{- include "common.initContainerWaitDatabase" . | nindent 8 }}
         {{- with .Values.lake.containerSecurityContext }}
           securityContext:
           {{- toYaml . | nindent 12 }}
+      {{- end }}
       {{- end }}
       containers:
         - name: lake
@@ -172,6 +174,10 @@ spec:
           {{- with .Values.lake.containerSecurityContext }}
           securityContext:
           {{- toYaml . | nindent 12 }}
+          {{- with .Values.lake.volumeMounts }}
+          volumeMounts:
+          {{- toYaml . | nindent 12 }}
+          {{- end }}
       {{- end }}
       {{- if .Values.lake.hostNetwork }}
       hostNetwork: true
@@ -187,6 +193,10 @@ spec:
       {{- end }}
       {{- with .Values.lake.tolerations }}
       tolerations:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.lake.volumes }}
+      volumes:
       {{- toYaml . | nindent 8 }}
   {{- end }}
 

--- a/charts/devlake/values.yaml
+++ b/charts/devlake/values.yaml
@@ -17,7 +17,7 @@
 
 # replica count for dev
 replicaCount: 1
-imageTag: v0.19.1-beta1
+imageTag: v0.19.1-beta2
 
 #the common environments for all pods except grafana, grafana needs to be set in grafana section seperately
 commonEnvs:
@@ -147,7 +147,7 @@ grafana:
     url: ""
   image:
     repository: devlake.docker.scarf.sh/apache/devlake-dashboard
-    tag: v0.19.1-beta1
+    tag: v0.19.1-beta2
   adminPassword: ""
   grafana.ini:
     server:

--- a/charts/devlake/values.yaml
+++ b/charts/devlake/values.yaml
@@ -17,7 +17,7 @@
 
 # replica count for dev
 replicaCount: 1
-imageTag: v0.19.1-beta2
+imageTag: v0.19.1-beta3
 
 #the common environments for all pods except grafana, grafana needs to be set in grafana section seperately
 commonEnvs:
@@ -147,7 +147,7 @@ grafana:
     url: ""
   image:
     repository: devlake.docker.scarf.sh/apache/devlake-dashboard
-    tag: v0.19.1-beta2
+    tag: v0.19.1-beta3
   adminPassword: ""
   grafana.ini:
     server:

--- a/charts/devlake/values.yaml
+++ b/charts/devlake/values.yaml
@@ -206,6 +206,10 @@ lake:
 
   podAnnotations: {}
 
+  volumeMounts: []
+
+  volumes: []
+
 ui:
   image:
     repository: devlake.docker.scarf.sh/apache/devlake-config-ui

--- a/charts/devlake/values.yaml
+++ b/charts/devlake/values.yaml
@@ -17,7 +17,7 @@
 
 # replica count for dev
 replicaCount: 1
-imageTag: v0.19.1-beta3
+imageTag: v0.19.0
 
 #the common environments for all pods except grafana, grafana needs to be set in grafana section seperately
 commonEnvs:
@@ -147,7 +147,7 @@ grafana:
     url: ""
   image:
     repository: devlake.docker.scarf.sh/apache/devlake-dashboard
-    tag: v0.19.1-beta3
+    tag: v0.19.0
   adminPassword: ""
   grafana.ini:
     server:


### PR DESCRIPTION
- update to v0.19.1-beta2 (#212)
- adjust to v0.19.1-beta3 (#222)
- adjust to v0.19.0 (#232)
- Remove init container when using an external db and add support for volumes
