### PR TITLE
Fix Grafana redirect loop

### DIFF
--- a/charts/devlake/values.yaml
+++ b/charts/devlake/values.yaml
@@ -156,6 +156,7 @@ grafana:
   adminPassword: ""
   grafana.ini:
     server:
+      serve_from_subpath: "true"
       root_url: "%(protocol)s://%(domain)s/grafana"
   #the secret name should be as same as .Values.option.connectionSecretName
   envFromSecrets:


### PR DESCRIPTION
Deploying the helmchart v0.21 (latest stable release to date), I've experienced a grafana redirect loop error (ERR_TOO_MANY_REDIRECTS). 

With this change on helm's values, the problem was gone.

Opened an issue: https://github.com/apache/incubator-devlake-helm-chart/issues/283

This PR fixes this problem.

However, as stated in the issue comments, @ZhangNing10 told me this "Serve from subpath" problem, should be an environment variable as it is declared on the Dockerfile (https://github.com/apache/incubator-devlake/commit/d52abffb6579b4231c7c587822a69d9cc6f7d043). However the version of the image i'm using does not include that.