### PR TITLE
feat: Add extraResources section

### DIFF
--- a/charts/devlake/templates/extraresources.yaml
+++ b/charts/devlake/templates/extraresources.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.extraResources }}
+{{- range .Values.extraResources }}
+---
+{{- $resource := . | deepCopy }}
+
+{{- $objectLabels := include "devlake.labels" $ | fromYaml }}
+
+{{- if $resource.metadata.labels }}
+{{- $objectLabels = merge $objectLabels $resource.metadata.labels }}
+{{- end }}
+
+{{ $_ := set $resource.metadata "labels" $objectLabels -}}
+
+{{ toYaml $resource | nindent 0 }}
+{{- end }}
+{{- end }}

--- a/charts/devlake/values.yaml
+++ b/charts/devlake/values.yaml
@@ -400,3 +400,16 @@ option:
   # the existing k8s secret name of db connection auth. The secret name should be as same as .Values.grafana.envFromSecret
   connectionSecretName: "devlake-mysql-auth"
   autoCreateSecret: true
+
+# Define some extra resources to be created
+# This section is useful when you need ExternalResource or Secrets, etc.
+extraResources: []
+  # - apiVersion: v1
+  #   kind: Secret
+  #   metadata:
+  #     name: example-secret
+  #     labels: {}
+  #   type: Opaque
+  #   stringData:
+  #     username: admin
+  #     password: mypassword


### PR DESCRIPTION
Hello there. I have added `extraResources` section into values as it's super useful in some scenarios needing credentials defined as ExternalSecret objects, or exposing devlake using HTTPRoute objects instead of Ingress.

WDYT? I think this is a little change but super useful :)  

CC: @abeizn @ZhangNing10 