### PR TITLE
Add container command to helm chart

### DIFF
--- a/charts/devlake/templates/deployments.yaml
+++ b/charts/devlake/templates/deployments.yaml
@@ -201,6 +201,10 @@ spec:
             - name: "{{ tpl $key2 $ }}"
               value: "{{ tpl (print $value2) $ }}"
             {{- end }}
+          {{- with .Values.lake.command }}
+          command:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- with .Values.lake.resources }}
           resources:
           {{- toYaml . | nindent 12 }}

--- a/charts/devlake/values.yaml
+++ b/charts/devlake/values.yaml
@@ -197,6 +197,8 @@ lake:
 
   #extra envs from an existing secret
   extraEnvsFromSecret: ""
+  # Set different container command
+  command: []
   encryptionSecret:
     # The name of secret which contains keys named ENCRYPTION_SECRET
     secretName: ""


### PR DESCRIPTION
Hey there, 

this PR addresses the need for changing the container startup command in the values file.
In my use case, I had to do so to update the ca-certificates before starting devlake as also advised in your docker compose docs:

https://devlake.apache.org/zh/docs/Troubleshooting/Configuration/#:~:text=command%3A%20%5B%20%22sh%22%2C%20%22%2Dc%22%2C%20%22update%2Dca%2Dcertificates%3B%20lake%22%20%5D

Kind regards