### PR TITLE
OCI distribution

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,6 +10,10 @@ on:
       - "!**.md"
   workflow_dispatch:
 
+permissions:
+  contents: write
+  packages: write
+
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -24,6 +28,13 @@ jobs:
         run: |
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Helm
         run: |
@@ -41,3 +52,12 @@ jobs:
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           CR_SKIP_EXISTING: false
+
+      - name: Push Chart to GHCR
+        run: |
+          for pkg in .cr-release-packages/*; do
+            if [ -z "${pkg:-}" ]; then
+              break
+            fi
+            helm push "${pkg}" oci://ghcr.io/${{ github.repository }}
+          done

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ ENCRYPTION_SECRET=$(openssl rand -base64 2000 | tr -dc 'A-Z' | fold -w 128 | hea
 helm install devlake devlake/devlake --version=1.0.2-beta4 --set lake.encryptionSecret.secret=$ENCRYPTION_SECRET
 ```
 
+Helm chart are also published to GitHub container registry as OCI artifact.
+
 If you are using minikube inside your mac, please use the following command to forward the port:
 
 ```shell


### PR DESCRIPTION
Fix #317 (more details there)

Provide chart as OCI artifact on GHCR 

I've tested the workflow changes on my fork: https://github.com/jonesbusy/incubator-devlake-helm-chart/actions/runs/12741995690

![chart](https://github.com/user-attachments/assets/0ae0ce03-09ec-4c04-911e-9e792fbd4b5c)

![chart2](https://github.com/user-attachments/assets/85828eee-b470-437a-a4a8-016bb870b39b)

