### PR TITLE
Issue with Mounting Certificate from ConfigMap in Grafana

### DIFF
--- a/charts/devlake/charts/grafana/templates/_pod.tpl
+++ b/charts/devlake/charts/grafana/templates/_pod.tpl
@@ -1134,17 +1134,20 @@ volumes:
       {{- toYaml .csi | nindent 6 }}
   {{- end }}
   {{- end }}
-  {{- range .Values.extraVolumeMounts }}
+  {{- range .Values.extraVolumes }}
   - name: {{ .name }}
     {{- if .existingClaim }}
     persistentVolumeClaim:
       claimName: {{ .existingClaim }}
     {{- else if .hostPath }}
     hostPath:
-      path: {{ .hostPath }}
+      {{ toYaml .hostPath | nindent 6 }}
     {{- else if .csi }}
     csi:
       {{- toYaml .data | nindent 6 }}
+    {{- else if .configMap }}
+    configMap:
+      {{- toYaml .configMap | nindent 6 }}
     {{- else }}
     emptyDir: {}
     {{- end }}

--- a/charts/devlake/charts/grafana/values.yaml
+++ b/charts/devlake/charts/grafana/values.yaml
@@ -507,6 +507,22 @@ extraSecretMounts: []
   #    nodePublishSecretRef:                       # Only required when using service principal mode
   #       name: grafana-akv-creds                  # Only required when using service principal mode
 
+## Additional Grafana server volumes
+extraVolumes: []
+  # - name: extra-volume-0
+  #   existingClaim: volume-claim
+  # - name: extra-volume-1
+  #   hostPath:
+  #     path: /usr/shared/
+  #     type: ""
+  # - name: grafana-secrets
+  #   csi:
+  #     driver: secrets-store.csi.k8s.io
+  #     readOnly: true
+  #     volumeAttributes:
+  #       secretProviderClass: "grafana-env-spc"
+
+
 ## Additional grafana server volume mounts
 # Defines additional volume mounts.
 extraVolumeMounts: []


### PR DESCRIPTION
#### Analysis
The issue seems to be caused by the Grafana version being a bit older. Specifically, the problem originates from this [line of code](https://github.com/apache/incubator-devlake-helm-chart/blob/5182bb4ed8dc6152d97054213f61cc07134bcd37/charts/devlake/charts/grafana/templates/_pod.tpl#L1137): 

```yaml
{{- range .Values.extraVolumeMounts }}
# It should instead use
{{- range .Values.extraVolumes }}
```

This issue appears to have been addressed in [this issue](https://github.com/prometheus-community/helm-charts/issues/3851) in the grafana community Helm charts.


#### Solution
 Fix the issue in the current Grafana version by modifying the template.