### PR TITLE
Support LoadBalancer service type and configurable loadBalancerIP

### DIFF
--- a/charts/devlake/templates/services.yaml
+++ b/charts/devlake/templates/services.yaml
@@ -27,6 +27,9 @@ metadata:
     {{- include "devlake.labels" . | nindent 4 }}
 spec:
   type: {{ .Values.mysql.service.type }}
+  {{- if and (eq .Values.mysql.service.type "LoadBalancer") .Values.mysql.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.mysql.service.loadBalancerIP }}
+  {{- end }}
   selector:
     {{- include "devlake.selectorLabels" . | nindent 4 }}
     devlakeComponent: mysql

--- a/charts/devlake/values.yaml
+++ b/charts/devlake/values.yaml
@@ -90,6 +90,7 @@ mysql:
   service:
     type: "ClusterIP"
     nodePort: ""
+    loadBalancerIP: ""
 
 # pgsql:
 #   # if use external pgsql server, please set true


### PR DESCRIPTION
This PR enhances the Helm chart by adding support for the LoadBalancer service type and allowing users to configure loadBalancerIP in values.yaml.

Changes:
✅ values.yaml

- Added LoadBalancer as an option for service.type
- Introduced service.loadBalancerIP (optional)

✅ templates/service.yaml

- Applied LoadBalancer configuration when service.type is set to LoadBalancer
- Set loadBalancerIP only if a value is provided

