### PR TITLE
feat: Improved convenience when using External Secrets through separation of ConfigMap and Secret

### DIFF
--- a/charts/devlake/templates/configmap.yaml
+++ b/charts/devlake/templates/configmap.yaml
@@ -1,0 +1,31 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "devlake.fullname" . }}-config
+  labels:
+    {{- include "devlake.labels" . | nindent 4 }}
+data:
+  # Database connection configuration (non-sensitive)
+{{- if (eq .Values.option.database "mysql") }}
+  MYSQL_USER: "{{ .Values.mysql.username }}"
+  MYSQL_DATABASE: "{{ .Values.mysql.database }}"
+  MYSQL_URL: "{{ include "mysql.server" . }}:{{ include "mysql.port" . }}"
+  DB_URL_TEMPLATE: "mysql://{{ .Values.mysql.username }}:${MYSQL_PASSWORD}@{{ include "mysql.server" . }}:{{ include "mysql.port" . }}/{{ .Values.mysql.database }}?charset=utf8mb4&parseTime=True&loc={{ .Values.commonEnvs.TZ }}"
+{{- end }}

--- a/charts/devlake/templates/deployments.yaml
+++ b/charts/devlake/templates/deployments.yaml
@@ -182,6 +182,8 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           envFrom:
+            - configMapRef:
+                name: {{ include "devlake.fullname" . }}-config
             - secretRef:
                 name: {{ include "devlake.mysql.secret" . }}
             - secretRef:

--- a/charts/devlake/templates/secrets.yaml
+++ b/charts/devlake/templates/secrets.yaml
@@ -22,17 +22,10 @@ metadata:
   name: {{ include "devlake.mysql.secret" . }}
 stringData:
 {{- if (eq .Values.option.database "mysql") }}
-  MYSQL_USER: "{{ .Values.mysql.username }}"
   MYSQL_PASSWORD: "{{ .Values.mysql.password }}"
-  MYSQL_DATABASE: "{{ .Values.mysql.database }}"
   MYSQL_ROOT_PASSWORD: "{{ .Values.mysql.rootPassword }}"
-  DB_URL: "{{ include "database.url" . }}"
-  MYSQL_URL: "{{ include "mysql.server" . }}:{{ include "mysql.port" . }}"
 #{{- else if (eq .Values.option.database "pgsql")}}
-#  POSTGRES_USER: "{{ .Values.pgsql.username }}"
 #  POSTGRES_PASSWORD: "{{ .Values.pgsql.password }}"
-#  POSTGRES_DB: "{{ .Values.pgsql.database }}"
-#  DB_URL: "{{ include "database.url" . }}"
 {{- end }}
 {{- end }}
 


### PR DESCRIPTION
# feat: Improved convenience when using External Secrets through separation of ConfigMap and Secret

## Overview
Separates MySQL configuration information into confidential and non-confidential data to improve integration with external secret management systems such as External Secret.

## Changes

### 🔧 Modified Files
- `charts/devlake/templates/secrets.yaml` - Modified to contain only confidential information
- `charts/devlake/templates/configmap.yaml` - Newly created: manages non-confidential settings
- `charts/devlake/templates/deployments.yaml` - Updated to reference both ConfigMap and Secret

### 📋 Detailed Changes

#### Secret (confidential information only)
```yaml
# Before changes
MYSQL_USER: "merico"           # Removed
MYSQL_PASSWORD: "merico"       # Retained
MYSQL_DATABASE: "lake"         # Removed  
MYSQL_ROOT_PASSWORD: "admin"   # Retained
DB_URL: "mysql://..."          # Removed
MYSQL_URL: "server:port"       # Removed

# After changes
MYSQL_PASSWORD: "merico"       # Retained
MYSQL_ROOT_PASSWORD: "admin"   # Retained
```

#### ConfigMap (non-confidential settings) - Newly created
```yaml
MYSQL_USER: "merico"
MYSQL_DATABASE: "lake"
MYSQL_URL: "server:port"
DB_URL_TEMPLATE: "mysql://user:${MYSQL_PASSWORD}@server:port/db?..."
```

#### Deployment
```yaml
envFrom:
  - configMapRef:              # Newly added
      name: devlake-config
  - secretRef:
      name: devlake-mysql-auth
```

## 🎯 Problems Resolved

### Issues Before Changes
- When injecting passwords with External Secret, `MYSQL_USER`, `MYSQL_DATABASE`, `MYSQL_URL` also needed to be managed externally
- Non-confidential information was included in Secret, which goes against Kubernetes best practices
- Secret updates were required when changing configurations

### Improvements After Changes
- External Secret only needs to manage passwords
- Configuration information is managed in ConfigMap and properly separated
- Follows Kubernetes best practices

## 🔄 Compatibility
- Maintains backward compatibility with existing deployments
- When `option.autoCreateSecret: true`, operates as before
- When using External Secret, only passwords need to be provided

## 📚 Related Issues
Fixes #336
