### PR TITLE
Fix grafana env from config map syntax

### DIFF
--- a/charts/devlake/values.yaml
+++ b/charts/devlake/values.yaml
@@ -199,9 +199,8 @@ grafana:
   envFromSecrets:
     - name: &devlake_mysql_auth "devlake-mysql-auth"
   # the ConfigMap name should be the same as .Values.option.connectionConfigmapName
-  extraEnvFrom:
-    - configMapRef:
-        name: &devlake_mysql_auth_config "devlake-mysql-auth-config"
+  envFromConfigMaps:
+    - name: &devlake_mysql_auth_config "devlake-mysql-auth-config"
   #keep grafana timezone same as other pods, which is set by .Values.commonEnvs.TZ
   env:
     TZ: "UTC"


### PR DESCRIPTION
I have confirmed that it is deployed correctly.

<img width="1284" height="594" alt="CleanShot 2025-09-11 at 19 49 45@2x" src="https://github.com/user-attachments/assets/2497afe7-0e6d-4e4e-ac46-5ce4fd5e7f75" />
