### PR TITLE
feat: use dedicated variable for securityContext for initContainers

### DIFF
--- a/charts/devlake/templates/deployments.yaml
+++ b/charts/devlake/templates/deployments.yaml
@@ -164,7 +164,7 @@ spec:
           {{- toYaml .Values.lake.initContainers | nindent 8 }}
         {{- end }}
         {{- include "common.initContainerWaitDatabase" . | nindent 8 }}
-        {{- with .Values.lake.containerSecurityContext }}
+        {{- with .Values.lake.initContainerSecurityContext }}
           securityContext:
           {{- toYaml . | nindent 12 }}
         {{- end }}

--- a/charts/devlake/values.yaml
+++ b/charts/devlake/values.yaml
@@ -267,6 +267,8 @@ lake:
 
   containerSecurityContext: {}
 
+  initContainerSecurityContext: {}
+
   podAnnotations: {}
 
   initContainers: []


### PR DESCRIPTION
I believe it should be a dedicated variable. My use case is to use `runAs` but the ID of the users are not the same on both images.