### PR TITLE
Make clusterDomain configurable in values.yaml

### DIFF
--- a/HelmSetup.md
+++ b/HelmSetup.md
@@ -147,6 +147,7 @@ Some useful parameters for the chart, you could also check them in values.yaml
 | imageTag                               | The version tag for all images                                                        | see Values.yaml          |
 | imagePullSecrets                       | Name of the Secret for accessing private image registries                             | []                       |
 | commonEnvs                             | The common envs for all pods except grafana                                           | {TZ: "UTC"}              |
+| clusterDomain                               | Kubernetes cluster domain                                                        | cluster.local          |
 | mysql.replicaCount                     | Replica count can only be 0 or 1                                                      | 1                        |
 | mysql.useExternal                      | If use external mysql server, set true                                                | false                    |
 | mysql.externalServer                   | External mysql server address                                                         | 127.0.0.1                |

--- a/charts/devlake/templates/deployments.yaml
+++ b/charts/devlake/templates/deployments.yaml
@@ -83,7 +83,7 @@ spec:
           {{- end }}
           env:
             - name: DEVLAKE_ENDPOINT
-              value: {{ include "devlake.fullname" . }}-lake.{{ .Release.Namespace }}.svc.cluster.local:8080
+              value: {{ include "devlake.fullname" . }}-lake.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:8080
 {{- if not .Values.grafana.enabled }}
             - name: GRAFANA_ENDPOINT
               value: {{ .Values.grafana.external.url }}
@@ -91,7 +91,7 @@ spec:
               value: "true"
 {{- else }}
             - name: GRAFANA_ENDPOINT
-              value: {{ .Release.Name }}-grafana.{{ .Release.Namespace }}.svc.cluster.local:80
+              value: {{ .Release.Name }}-grafana.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:80
 {{- end }}
             {{- range $key, $value := .Values.commonEnvs }}
             - name: "{{ tpl $key $ }}"

--- a/charts/devlake/values.yaml
+++ b/charts/devlake/values.yaml
@@ -26,6 +26,9 @@ imagePullSecrets: []
 commonEnvs:
   TZ: "UTC"
 
+# kubernetes cluster domain
+clusterDomain: cluster.local
+
 mysql:
   replicaCount: 1
   # if use external mysql server, please set true


### PR DESCRIPTION
## What changes were introduced?

- Added a new configurable `clusterDomain` parameter to `values.yaml` with default value `cluster.local`
- Replaced all hardcoded occurrences of `cluster.local` with `{{ .Values.clusterDomain }}` in Helm templates
- Updated relevant documentation (HelmSetup.dm)

## Why is this change needed?

Currently, the Helm chart contains hardcoded `cluster.local` references which makes it incompatible with Kubernetes clusters using different cluster domains (e.g., OpenShift, RKE, custom installations). This change adds flexibility while maintaining full backward compatibility.

## Key features:
- **Backward compatible**: Default value remains `cluster.local` – existing installations unaffected
- **Configurable**: Users can now specify custom cluster domains via values
- **Standards-aligned**: Uses common Kubernetes terminology (`clusterDomain`)

## Usage example:
```yaml
# Custom cluster domain
clusterDomain: "internal.k8s.local"

# Or use default
# clusterDomain: "cluster.local"