### PR TITLE
feat: add support for custom serviceAccount name for lake and ui deployments

### DIFF
--- a/charts/devlake/templates/deployments.yaml
+++ b/charts/devlake/templates/deployments.yaml
@@ -51,6 +51,9 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.ui.serviceAccount.name }}
+      serviceAccountName: {{ . }}
+      {{- end }}
       {{- with .Values.ui.securityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}
@@ -154,6 +157,9 @@ spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.lake.serviceAccount.name }}
+      serviceAccountName: {{ . }}
       {{- end }}
       {{- with .Values.lake.securityContext }}
       securityContext:

--- a/charts/devlake/values.yaml
+++ b/charts/devlake/values.yaml
@@ -265,6 +265,11 @@ lake:
   #     subPath: test_file.yaml
   volumeMounts: []
 
+  # Name of an existing ServiceAccount to use for the lake pod.
+  # If empty, the pod uses the namespace default ServiceAccount.
+  serviceAccount:
+    name: ""
+
 ui:
   replicaCount: 1
   revisionHistoryLimit: 10
@@ -343,6 +348,11 @@ ui:
 
   ## Side Contaainer Configuration
   extraContainers: []
+
+  # Name of an existing ServiceAccount to use for the config-ui pod.
+  # If empty, the pod uses the namespace default ServiceAccount.
+  serviceAccount:
+    name: ""
 #  - name: vault-agent
 #    image: vault:1.6.2
 #    args:


### PR DESCRIPTION
## What changes were introduced?

- Added optional `serviceAccount.name` parameter to `lake` and `ui` sections in `values.yaml`
- Updated `lake` and `ui` deployment templates to conditionally set `serviceAccountName` when a value is provided

## Why is this change needed?

Currently, the Helm chart offers no way to assign a custom ServiceAccount to the `lake` or `ui` pods. They always fall back to the namespace default. This is a common requirement in environments with fine-grained RBAC, Workload Identity (GCP) or other pod-level identity mechanisms.

## Key features:
- **Backward compatible**: fields default to empty. Existing installations are unaffected.
- **Non-invasive**: `serviceAccountName` is only injected into the pod spec when a name is explicitly provided

## Usage example:
```yaml
lake:
  serviceAccount:
    name: "devlake-lake-sa"

ui:
  serviceAccount:
    name: "devlake-ui-sa"
```