### PR TITLE
chore(name): remove reference to old name incubator-*

### DIFF
--- a/HelmSetup.md
+++ b/HelmSetup.md
@@ -14,14 +14,14 @@ sidebar_position: 2
 
 ## 2 Quick Start
 
-**Check https://github.com/apache/incubator-devlake-helm-chart to contribute!**
+**Check https://github.com/apache/devlake-helm-chart to contribute!**
 
 ### 2.1 Install
 
 To install the chart with release name `devlake`:
 
 ```shell
-helm repo add devlake https://apache.github.io/incubator-devlake-helm-chart
+helm repo add devlake https://apache.github.io/devlake-helm-chart
 helm repo update
 ENCRYPTION_SECRET=$(openssl rand -base64 2000 | tr -dc 'A-Z' | fold -w 128 | head -n 1)
 helm install devlake devlake/devlake --version=1.0.3-beta10 --set lake.encryptionSecret.secret=$ENCRYPTION_SECRET
@@ -238,7 +238,7 @@ b. Proviede below values while install from helm:
 Here is the example:
 
 ```
-helm repo add devlake https://apache.github.io/incubator-devlake-helm-chart
+helm repo add devlake https://apache.github.io/devlake-helm-chart
 helm repo update
 ENCRYPTION_SECRET=$(openssl rand -base64 2000 | tr -dc 'A-Z' | fold -w 128 | head -n 1)
 helm install devlake devlake/devlake \
@@ -274,7 +274,7 @@ Yes, the devlake helm chart supports using an external Grafana. You can set the 
 Here is the example:
 
 ```
-helm repo add devlake https://apache.github.io/incubator-devlake-helm-chart
+helm repo add devlake https://apache.github.io/devlake-helm-chart
 helm repo update
 ENCRYPTION_SECRET=$(openssl rand -base64 2000 | tr -dc 'A-Z' | fold -w 128 | head -n 1)
 helm install devlake devlake/devlake \
@@ -291,7 +291,7 @@ helm install devlake devlake/devlake \
 Here is the example:
 
 ```
-helm repo add devlake https://apache.github.io/incubator-devlake-helm-chart
+helm repo add devlake https://apache.github.io/devlake-helm-chart
 helm repo update
 ENCRYPTION_SECRET=$(openssl rand -base64 2000 | tr -dc 'A-Z' | fold -w 128 | head -n 1)
 helm install devlake devlake/devlake \
@@ -304,4 +304,4 @@ helm install devlake devlake/devlake \
 
 ## 6 Troubleshooting
 
-If you run into any problem, please check the [Troubleshooting](/Troubleshooting/Installation.md) or [create an issue](https://github.com/apache/incubator-devlake/issues)
+If you run into any problem, please check the [Troubleshooting](/Troubleshooting/Installation.md) or [create an issue](https://github.com/apache/devlake/issues)

--- a/README.md
+++ b/README.md
@@ -19,14 +19,14 @@
 #
 -->
 
-Thanks to @matrixji who initiated all content in `apache/incubator-devlake`, this repo is copied from directory deployment/helm in repo `apache/incubator-devlake`! Also thanks to @lshmouse, @shubham-cmyk and @SnowMoon-Dev for the contribution for devlake helm deployment.
+Thanks to @matrixji who initiated all content in `apache/devlake`, this repo is copied from directory deployment/helm in repo `apache/devlake`! Also thanks to @lshmouse, @shubham-cmyk and @SnowMoon-Dev for the contribution for devlake helm deployment.
 
 ## Install
 
 1. Install the latest stable version with release name `devlake`
 
 ```shell
-helm repo add devlake https://apache.github.io/incubator-devlake-helm-chart
+helm repo add devlake https://apache.github.io/devlake-helm-chart
 helm repo update
 ENCRYPTION_SECRET=$(openssl rand -base64 2000 | tr -dc 'A-Z' | fold -w 128 | head -n 1)
 helm install devlake devlake/devlake --set lake.encryptionSecret.secret=$ENCRYPTION_SECRET
@@ -35,7 +35,7 @@ helm install devlake devlake/devlake --set lake.encryptionSecret.secret=$ENCRYPT
 2. Install the latest development version with release name `devlake`:
 
 ```shell
-helm repo add devlake https://apache.github.io/incubator-devlake-helm-chart
+helm repo add devlake https://apache.github.io/devlake-helm-chart
 helm repo update
 ENCRYPTION_SECRET=$(openssl rand -base64 2000 | tr -dc 'A-Z' | fold -w 128 | head -n 1)
 helm install devlake devlake/devlake --version=1.0.3-beta10 --set lake.encryptionSecret.secret=$ENCRYPTION_SECRET
@@ -91,9 +91,9 @@ To uninstall/delete the `devlake` release:
 helm uninstall devlake
 ```
 
-## Original pr in apache/incubator-devlake
+## Original pr in apache/devlake
 
-https://github.com/apache/incubator-devlake/pulls?q=is%3Apr+helm+is%3Aclosed
+https://github.com/apache/devlake/pulls?q=is%3Apr+helm+is%3Aclosed
 
 ## More
 

--- a/ReleaseSOP.md
+++ b/ReleaseSOP.md
@@ -1,7 +1,7 @@
 ## How to upgrade helm chart after releasing new devlake images
 
-1. In [values.yaml](https://github.com/apache/incubator-devlake-helm-chart/blob/main/charts/devlake/values.yaml), change {{ imageTag }} to current image tag
-2. In [chart.yaml](https://github.com/apache/incubator-devlake-helm-chart/blob/main/charts/devlake/Chart.yaml), change {{ version }}, {{ appVersion }} to current image tag
+1. In [values.yaml](https://github.com/apache/devlake-helm-chart/blob/main/charts/devlake/values.yaml), change {{ imageTag }} to current image tag
+2. In [chart.yaml](https://github.com/apache/devlake-helm-chart/blob/main/charts/devlake/Chart.yaml), change {{ version }}, {{ appVersion }} to current image tag
 3. If we want to release a new chart without new release of devlake, we should increase both chart version and image tag.
    - For example, right now both versions are 0.16.1-beta1, if we make change on chart, we should set chart-version to 0.16.1-beta1, also, we need to crate new images for devlake with tag 0.16.1-beta1
 4. If we release any new image for devlake, we just need to set a new version for chart.

--- a/charts/devlake/Chart.yaml
+++ b/charts/devlake/Chart.yaml
@@ -20,8 +20,8 @@ description: Apache DevLake is an open-source dev data platform that ingests, an
 home: https://devlake.apache.org/
 icon: https://devlake.apache.org/img/logo.svg
 sources:
-  - https://github.com/apache/incubator-devlake
-  - https://github.com/apache/incubator-devlake-helm-chart
+  - https://github.com/apache/devlake
+  - https://github.com/apache/devlake-helm-chart
 keywords:
   - devlake
 

--- a/charts/devlake/templates/validate.yaml
+++ b/charts/devlake/templates/validate.yaml
@@ -1,6 +1,6 @@
 {{- if and .Values.lake.encryptionSecret.autoCreateSecret (not .Values.lake.encryptionSecret.secret) }}
 {{- fail
-"Helm test requires lake.encryptionSecret.secret.\n\n  - If you're upgrading from DevLake v0.17.x or earlier versions, please get the encryption secret by copying the ENCODE_KEY value from /app/config/.env of the lake pod (e.g. devlake-lake-0);\n  - If upgrading from v0.18.0+, get the original secret in k8s secret and decode it\n  - If new installation, get the encryption secret via command `openssl rand -base64 2000 | tr -dc 'A-Z' | fold -w 128 | head -n 1`.\n\nFor more information, please check https://github.com/apache/incubator-devlake-helm-chart"
+"Helm test requires lake.encryptionSecret.secret.\n\n  - If you're upgrading from DevLake v0.17.x or earlier versions, please get the encryption secret by copying the ENCODE_KEY value from /app/config/.env of the lake pod (e.g. devlake-lake-0);\n  - If upgrading from v0.18.0+, get the original secret in k8s secret and decode it\n  - If new installation, get the encryption secret via command `openssl rand -base64 2000 | tr -dc 'A-Z' | fold -w 128 | head -n 1`.\n\nFor more information, please check https://github.com/apache/devlake-helm-chart"
 }}
 {{- end }}
 


### PR DESCRIPTION
The repos were renamed but the old naming was left in the repo. This also breaks the helm charts

Closes https://github.com/apache/devlake-helm-chart/issues/375